### PR TITLE
Adds schema validation workflow

### DIFF
--- a/.github/workflows/validate_schema.yaml
+++ b/.github/workflows/validate_schema.yaml
@@ -1,0 +1,36 @@
+name: Validate Schema
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize]
+
+jobs:
+  validate_schema_correctness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Validate schema
+        run: |
+          npx ajv-cli compile \
+                    --spec=draft7 \
+                    --allow-union-types \
+                    -s workflow-schema.json
+  validate_samples_with_schema:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Validate json with schema
+        run: |
+          npx ajv-cli validate \
+                    --spec=draft7 \
+                    --allow-union-types \
+                    -s workflow-schema.json \
+                    -d sample.json
+      - name: Validate yaml with schema
+        run: |
+          npx ajv-cli validate \
+                    --spec=draft7 \
+                    --allow-union-types \
+                    -s workflow-schema.json \
+                    -d sample.yaml

--- a/workflow-schema.json
+++ b/workflow-schema.json
@@ -103,7 +103,6 @@
       "title": "The sequence of FlowRepresentables the workflow should contain",
       "minItems": 1,
       "type": "array",
-      "additionalItems": true,
       "items": {
         "$id": "#/properties/sequence/items",
         "anyOf": [
@@ -182,8 +181,7 @@
                 "title": "The name of the FlowPersistence in the workflow",
                 "$ref": "#/properties/sequence/items/definitions/nonEmptyStringOrObject"
               }
-            },
-            "additionalProperties": true
+            }
           }
         ],
         "definitions": {
@@ -195,6 +193,5 @@
         }
       }
     }
-  },
-  "additionalProperties": true
+  }
 }


### PR DESCRIPTION
Uses [ajv](https://github.com/ajv-validator/ajv-cli) to validate our json schema and validate our sample specs against the schema. This workflow runs in the PR as a way to have a pre-merge guard against issues in the schema or sample specs.

<!-- All PRs should have some kind of issue backing them. This means the community has had some opportunity to contribute ideas, or that the PR is fixing a problem that is being tracked -->
### Linked Issue: #10 

<!-- (See our contributing guidelines for more details) -->

<!-- Please remove any items below that may not apply to your Pull Request -->
## Checklist:
- [x] Did you sign the [Contributor License Agreement](https://cla-assistant.io/wwt/WorkflowSchema)?
- [x] Did you read the [contribution guidelines](https://github.com/wwt/WorkflowSchema/blob/main/.github/CONTRIBUTING.md)?